### PR TITLE
qa: remove cache dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- Remove `laminas/laminas-cache` dependency to avoid circular dependencies.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,12 @@
     "cache/integration-tests": "^0.16",
     "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
   },
+  "conflict": {
+    "laminas/laminas-cache": "<2.10"
+  },
   "require-dev": {
-    "squizlabs/php_codesniffer": "^3.5",
-    "laminas/laminas-cache": "^2.10"
+    "laminas/laminas-cache": "^2.10",
+    "squizlabs/php_codesniffer": "^3.5"
   },
   "config": {
     "sort-packages": true
@@ -28,22 +31,19 @@
       "test/autoload.php"
     ]
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "scripts": {
     "cs-check": "phpcs",
     "cs-fix": "phpcbf",
     "test": "phpunit --colors=always",
     "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
   },
-  "prefer-stable": true,
-  "minimum-stability": "dev",
   "support": {
     "issues": "https://github.com/laminas/laminas-cache-storage-adapter-test/issues",
     "forum": "https://discourse.laminas.dev/",
     "source": "https://github.com/laminas/laminas-cache-storage-adapter-test",
     "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-test/",
     "rss": "https://github.com/laminas/laminas-cache-storage-adapter-test/releases.atom"
-  },
-  "conflict": {
-    "laminas/laminas-cache": "<2.10"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,47 +1,49 @@
 {
-    "name": "laminas/laminas-cache-storage-adapter-test",
-    "description": "Laminas cache storage adapter shared test dependency",
-    "keywords": [
-        "laminas",
-        "cache",
-        "test"
-    ],
-    "license": "BSD-3-Clause",
-    "require": {
-        "php": "^5.6 || ^7.0",
-        "cache/integration-tests": "^0.16",
-        "laminas/laminas-cache": "^2.10",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+  "name": "laminas/laminas-cache-storage-adapter-test",
+  "description": "Laminas cache storage adapter shared test dependency",
+  "keywords": [
+    "laminas",
+    "cache",
+    "test"
+  ],
+  "license": "BSD-3-Clause",
+  "require": {
+    "php": "^5.6 || ^7.0",
+    "cache/integration-tests": "^0.16",
+    "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": "^3.5",
+    "laminas/laminas-cache": "^2.10"
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {},
+  "autoload": {
+    "psr-4": {
+      "LaminasTest\\Cache\\Storage\\Adapter\\": "src/"
     },
-    "require-dev": {
-        "squizlabs/php_codesniffer": "^3.5"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-    },
-    "autoload": {
-        "psr-4": {
-            "LaminasTest\\Cache\\Storage\\Adapter\\": "src/"
-        },
-        "files": [
-            "test/autoload.php"
-        ]
-    },
-    "scripts": {
-        "cs-check": "phpcs",
-        "cs-fix": "phpcbf",
-        "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
-    },
-    "prefer-stable": true,
-    "minimum-stability": "dev",
-    "support": {
-        "issues": "https://github.com/laminas/laminas-cache-storage-adapter-test/issues",
-        "forum": "https://discourse.laminas.dev/",
-        "source": "https://github.com/laminas/laminas-cache-storage-adapter-test",
-        "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-test/",
-        "rss": "https://github.com/laminas/laminas-cache-storage-adapter-test/releases.atom"
-    }
+    "files": [
+      "test/autoload.php"
+    ]
+  },
+  "scripts": {
+    "cs-check": "phpcs",
+    "cs-fix": "phpcbf",
+    "test": "phpunit --colors=always",
+    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+  },
+  "prefer-stable": true,
+  "minimum-stability": "dev",
+  "support": {
+    "issues": "https://github.com/laminas/laminas-cache-storage-adapter-test/issues",
+    "forum": "https://discourse.laminas.dev/",
+    "source": "https://github.com/laminas/laminas-cache-storage-adapter-test",
+    "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-test/",
+    "rss": "https://github.com/laminas/laminas-cache-storage-adapter-test/releases.atom"
+  },
+  "conflict": {
+    "laminas/laminas-cache": "<2.10"
+  }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Removing `laminas/laminas-cache` dependency to avoid circular dependency conflicts.