### PR TITLE
bugfix: do not overwrite php datatypes

### DIFF
--- a/src/CommonAdapterTest.php
+++ b/src/CommonAdapterTest.php
@@ -32,15 +32,15 @@ abstract class CommonAdapterTest extends AbstractCommonAdapterTest
     /**
      * All datatypes of PHP
      *
-     * @var string[]
+     * @var string[]|null
      */
-    protected $_phpDatatypes = [];
+    protected $_phpDatatypes;
 
     protected function setUp(): void
     {
         $this->storage = $this->_storage;
         $this->options = $this->_options;
-        $this->phpDatatypes = $this->_phpDatatypes;
+        $this->phpDatatypes = $this->_phpDatatypes ?? $this->phpDatatypes;
 
         parent::setUp();
     }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Even tho, that bumping phpunit was a BC break already, the property `phpDatatypes` should not be overridden with an empty array.
