### PR TITLE
Enforce integer for `usleep` calls

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -269,17 +269,6 @@
     </UnusedVariable>
   </file>
   <file src="src/AbstractCommonAdapterTest.php">
-    <InvalidArgument occurrences="9">
-      <code>$capabilities-&gt;getTtlPrecision() * 1000000</code>
-      <code>$capabilities-&gt;getTtlPrecision() * 1000000</code>
-      <code>$capabilities-&gt;getTtlPrecision() * 2000000</code>
-      <code>$wait * 2000000</code>
-      <code>$wait * 2000000</code>
-      <code>$wait * 2000000</code>
-      <code>$wait * 2000000</code>
-      <code>$wait * 2000000</code>
-      <code>$wait * 2000000</code>
-    </InvalidArgument>
     <MixedArgument occurrences="2">
       <code>$supportedMetadata</code>
       <code>$supportedMetadata</code>

--- a/src/AbstractCommonAdapterTest.php
+++ b/src/AbstractCommonAdapterTest.php
@@ -247,7 +247,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
 
         // wait until the item expired
         $wait = $ttl + $capabilities->getTtlPrecision();
-        usleep($wait * 2000000);
+        usleep((int) $wait * 2000000);
 
         if (! $capabilities->getUseRequestTime()) {
             $this->assertFalse($this->storage->hasItem('key'));
@@ -324,7 +324,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
 
         // wait until expired
         $wait = $ttl + $capabilities->getTtlPrecision();
-        usleep($wait * 2000000);
+        usleep((int) $wait * 2000000);
 
         $this->assertNull($this->storage->getItem('key'));
     }
@@ -583,7 +583,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
 
         // wait until expired
         $wait = $ttl + $capabilities->getTtlPrecision();
-        usleep($wait * 2000000);
+        usleep((int) $wait * 2000000);
 
         if ($capabilities->getUseRequestTime()) {
             // Can't test much more if the request time will be used
@@ -633,7 +633,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
 
         // wait until expired
         $wait = $ttl + $capabilities->getTtlPrecision();
-        usleep($wait * 2000000);
+        usleep((int) $wait * 2000000);
 
         $rs = $this->storage->getItems(array_keys($items));
         ksort($rs); // make comparable
@@ -769,7 +769,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
 
         // wait until the item expired
         $wait = $ttl + $capabilities->getTtlPrecision();
-        usleep($wait * 2000000);
+        usleep((int) $wait * 2000000);
 
         if (! $capabilities->getUseRequestTime()) {
             $this->assertFalse($this->storage->hasItem('key'));
@@ -975,14 +975,14 @@ abstract class AbstractCommonAdapterTest extends TestCase
         $this->assertTrue($this->storage->setItem('key', 'value'));
 
         // sleep 1 times before expire to touch the item
-        usleep($capabilities->getTtlPrecision() * 1000000);
+        usleep((int) $capabilities->getTtlPrecision() * 1000000);
         $this->assertTrue($this->storage->touchItem('key'));
 
-        usleep($capabilities->getTtlPrecision() * 1000000);
+        usleep((int) $capabilities->getTtlPrecision() * 1000000);
         $this->assertTrue($this->storage->hasItem('key'));
 
         if (! $capabilities->getUseRequestTime()) {
-            usleep($capabilities->getTtlPrecision() * 2000000);
+            usleep((int) $capabilities->getTtlPrecision() * 2000000);
             $this->assertFalse($this->storage->hasItem('key'));
         }
     }
@@ -1150,7 +1150,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
 
         // wait until the first item expired
         $wait = $ttl + $capabilities->getTtlPrecision();
-        usleep($wait * 2000000);
+        usleep((int) $wait * 2000000);
 
         $this->assertTrue($this->storage->setItem('key2', 'value2'));
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes/no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

`usleep` signature says it requires `int` so we should enforce integer by casting the wait time.
