### PR TITLE
Re-enable `testHasItemReturnsFalseWhenDeferredItemIsExpired`

### DIFF
--- a/src/AbstractCacheItemPoolIntegrationTest.php
+++ b/src/AbstractCacheItemPoolIntegrationTest.php
@@ -13,7 +13,6 @@ use Psr\Cache\CacheItemPoolInterface;
 use function date_default_timezone_get;
 use function date_default_timezone_set;
 use function get_class;
-use function sprintf;
 
 abstract class AbstractCacheItemPoolIntegrationTest extends CachePoolTest
 {
@@ -25,18 +24,6 @@ abstract class AbstractCacheItemPoolIntegrationTest extends CachePoolTest
 
     protected function setUp(): void
     {
-        $deferredSkippedMessage = sprintf(
-            '%s storage doesn\'t support driver deferred',
-            $this->getStorageAdapterClassName(),
-        );
-
-        /**
-         * @link           https://github.com/php-cache/integration-tests/issues/115
-         *
-         * @psalm-suppress MixedArrayAssignment
-         */
-        $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
-
         parent::setUp();
         // set non-UTC timezone
         $this->tz = date_default_timezone_get();


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This re-enables the `testHasItemReturnsFalseWhenDeferredItemIsExpired` check as it was disabled after adding the PSR-6 integration test capability to this component.

I also closed my question in https://github.com/php-cache/integration-tests/issues/115 since I got these question answered by PHP-FIG core committee members.

```
Crell — 07/05/2022

Hm.  I think that's currently undefined, on the implicit assumption that the delta between calling saveDeferred() and commit() is going to be less than a second, so it doesn't really matter.  (This assumption may not be true in 100% of cases, but should be in most.)
```

```
alekitto — 07/06/2022

Your point is clear. Though whether the interval of the expireAfter starts from the commit call is debatable: to me seems completely correct to start decrementing the expiration counter just after the expireAfter call.  deferred refers to the save operation, not to the expiration of items
```