### PR TITLE
Ensure wait time actually exceeds the TTL

### DIFF
--- a/src/AbstractCommonAdapterTest.php
+++ b/src/AbstractCommonAdapterTest.php
@@ -1181,7 +1181,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
         self::assertTrue($this->storage->setItem('key1', 'value1'));
 
         // wait until the first item expired
-        $wait = (int) ($ttl + $capabilities->getTtlPrecision() * 2000);
+        $wait = (int) ($ttl + $capabilities->getTtlPrecision() * 2000000);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
         usleep($wait);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With v2.1.0, I accidentally introduced a bug while modifying code to provide better type-safety.
This restores the appropriate wait time so the cache items can properly expire.

I will provide integration tests for this component in a dedicated PR.


https://github.com/laminas/laminas-cache-storage-adapter-test/commit/7a9e105f329c7ad438225bbd09511f12af804d8c#diff-1522038cf55d12620202b62dd3beb4d2d09876ea3c9d99a359c440b3f78f109eR1183-R1186