### PR TITLE
Merge release 2.2.1 into 2.3.x

### DIFF
--- a/src/AbstractCommonAdapterTest.php
+++ b/src/AbstractCommonAdapterTest.php
@@ -1181,7 +1181,7 @@ abstract class AbstractCommonAdapterTest extends TestCase
         self::assertTrue($this->storage->setItem('key1', 'value1'));
 
         // wait until the first item expired
-        $wait = (int) ($ttl + $capabilities->getTtlPrecision() * 2000);
+        $wait = (int) ($ttl + $capabilities->getTtlPrecision() * 2000000);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
         usleep($wait);


### PR DESCRIPTION
### Release Notes for [2.2.1](https://github.com/laminas/laminas-cache-storage-adapter-test/milestone/15)

2.2.x bugfix release (patch)

### 2.2.1

- Total issues resolved: **0**
- Total pull requests resolved: **1**
- Total contributors: **1**

 - [36: Merge release 2.1.1 into 2.2.x](https://github.com/laminas/laminas-cache-storage-adapter-test/pull/36) thanks to @github-actions[bot]
