### PR TITLE
Remove `cache/integration-tests` dependency

### DIFF
--- a/autoload/phpunit-backward-compatibility.php
+++ b/autoload/phpunit-backward-compatibility.php
@@ -1,7 +1,0 @@
-<?php
-
-use PHPUnit\Framework\TestCase;
-
-if (! class_exists('PHPUnit_Framework_TestCase')) {
-    class_alias(TestCase::class, 'PHPUnit_Framework_TestCase');
-}

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,16 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
-        "cache/integration-tests": "dev-master",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "container-interop/container-interop": "^1.2",
         "laminas/laminas-cache": "^3.1",
-        "phpunit/phpunit": "^9.5.20"
+        "phpunit/phpunit": "^9.5.20",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "laminas/laminas-cache-storage-adapter-apcu": "^2.0",
-        "laminas/laminas-cache-storage-adapter-memory": "^1.1",
+        "laminas/laminas-cache-storage-adapter-memory": "^2.0",
         "laminas/laminas-coding-standard": "~2.3.0",
         "psalm/plugin-phpunit": "^0.17.0",
         "vimeo/psalm": "^4.23.0"
@@ -24,7 +25,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.3.99"
+            "php": "7.4.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -34,10 +35,7 @@
     "autoload": {
         "psr-4": {
             "LaminasTest\\Cache\\Storage\\Adapter\\": "src/"
-        },
-        "files": [
-            "autoload/phpunit-backward-compatibility.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,73 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd1cec89e3d1fa8bd11d92483ee51d4d",
+    "content-hash": "fe29811d7285a8db8bd9e4c72dd89a02",
     "packages": [
-        {
-            "name": "cache/integration-tests",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/integration-tests.git",
-                "reference": "824633c9547dc3c7ac5faeca03dd82939cdeb73c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/824633c9547dc3c7ac5faeca03dd82939cdeb73c",
-                "reference": "824633c9547dc3c7ac5faeca03dd82939cdeb73c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "require-dev": {
-                "cache/cache": "^1.0",
-                "illuminate/cache": "^5.4|^5.5|^5.6",
-                "mockery/mockery": "^1.0",
-                "symfony/cache": "^3.4.31|^4.3.4|^5.0",
-                "symfony/phpunit-bridge": "^5.1",
-                "tedivm/stash": "^0.14"
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cache\\IntegrationTests\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Scherer",
-                    "email": "aequasi@gmail.com",
-                    "homepage": "https://github.com/aequasi"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
-                }
-            ],
-            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
-            "homepage": "https://github.com/php-cache/integration-tests",
-            "keywords": [
-                "cache",
-                "psr16",
-                "psr6",
-                "test"
-            ],
-            "support": {
-                "issues": "https://github.com/php-cache/integration-tests/issues",
-                "source": "https://github.com/php-cache/integration-tests/tree/master"
-            },
-            "time": "2021-02-04T19:17:10+00:00"
-        },
         {
             "name": "container-interop/container-interop",
             "version": "1.2.0",
@@ -278,34 +213,40 @@
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
-            "version": "1.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
-                "reference": "02c7a4a1118bbd47d1c0f0bfe1e8b140af79d2bd"
+                "reference": "f47aed9d5f6f3eac5970693ea5898d67d3f33dcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/02c7a4a1118bbd47d1c0f0bfe1e8b140af79d2bd",
-                "reference": "02c7a4a1118bbd47d1c0f0bfe1e8b140af79d2bd",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/f47aed9d5f6f3eac5970693ea5898d67d3f33dcf",
+                "reference": "f47aed9d5f6f3eac5970693ea5898d67d3f33dcf",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0"
-            },
-            "conflict": {
-                "laminas/laminas-cache": "<2.10"
+                "laminas/laminas-cache": "^3.0",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "provide": {
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^2.10.1",
-                "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
-                "laminas/laminas-coding-standard": "^2.1.4",
-                "squizlabs/php_codesniffer": "^3.5.8"
+                "laminas/laminas-cache": "3.0.x-dev",
+                "laminas/laminas-cache-storage-adapter-benchmark": "^1.0",
+                "laminas/laminas-cache-storage-adapter-test": "2.0.x-dev",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.9"
             },
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Memory\\ConfigProvider",
+                    "module": "Laminas\\Cache\\Storage\\Adapter\\Memory"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Laminas\\Cache\\Storage\\Adapter\\": "src/"
@@ -333,7 +274,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-04-28T17:27:13+00:00"
+            "time": "2021-11-08T22:17:24+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
@@ -4913,17 +4854,15 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "cache/integration-tests": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0"
+        "php": "^7.4 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.99"
+        "php": "7.4.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -28,6 +28,11 @@
                 <file name="src/AbstractCacheItemPoolIntegrationTest.php"/>
             </errorLevel>
         </MixedArgument>
+        <MixedArgumentTypeCoercion>
+            <errorLevel type="suppress">
+                <file name="src/AbstractCacheItemPoolIntegrationTest.php"/>
+            </errorLevel>
+        </MixedArgumentTypeCoercion>
         <MixedAssignment>
             <errorLevel type="suppress">
                 <file name="src/AbstractSimpleCacheIntegrationTest.php"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,17 +4,47 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedPsalmSuppress="true"
 >
     <projectFiles>
         <directory name="src"/>
         <directory name="test"/>
         <ignoreFiles>
-            <directory name="docs"/>
             <directory name="vendor"/>
             <directory name="test/unit/TestAsset"/>
             <directory name="test/integration/TestAsset"/>
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <RedundantConditionGivenDocblockType>
+            <errorLevel type="suppress">
+                <file name="src/AbstractSimpleCacheIntegrationTest.php"/>
+                <file name="src/AbstractCacheItemPoolIntegrationTest.php"/>
+            </errorLevel>
+        </RedundantConditionGivenDocblockType>
+        <MixedArgument>
+            <errorLevel type="suppress">
+                <file name="src/AbstractSimpleCacheIntegrationTest.php"/>
+                <file name="src/AbstractCacheItemPoolIntegrationTest.php"/>
+            </errorLevel>
+        </MixedArgument>
+        <MixedAssignment>
+            <errorLevel type="suppress">
+                <file name="src/AbstractSimpleCacheIntegrationTest.php"/>
+            </errorLevel>
+        </MixedAssignment>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <file name="src/AbstractSimpleCacheIntegrationTest.php"/>
+                <file name="src/AbstractCacheItemPoolIntegrationTest.php"/>
+            </errorLevel>
+        </InvalidArgument>
+        <PossiblyNullReference>
+            <errorLevel type="suppress">
+                <file name="src/AbstractCacheItemPoolIntegrationTest.php"/>
+            </errorLevel>
+        </PossiblyNullReference>
+    </issueHandlers>
 
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/AbstractCacheItemPoolIntegrationTest.php
+++ b/src/AbstractCacheItemPoolIntegrationTest.php
@@ -4,23 +4,49 @@ declare(strict_types=1);
 
 namespace LaminasTest\Cache\Storage\Adapter;
 
-use Cache\IntegrationTests\CachePoolTest;
+use DateTimeImmutable;
 use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
 use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use stdClass;
+use Traversable;
 
+use function chr;
+use function count;
 use function date_default_timezone_get;
 use function date_default_timezone_set;
+use function gc_collect_cycles;
 use function get_class;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+use function iterator_to_array;
+use function sleep;
+use function str_repeat;
+use function time;
 
-abstract class AbstractCacheItemPoolIntegrationTest extends CachePoolTest
+abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
 {
-    /** @var string|null */
-    private $tz;
+    private ?string $tz = null;
 
-    /** @var StorageInterface|null */
-    private $storage;
+    private ?StorageInterface $storage = null;
+
+    /**
+     * Map of test name and the reason why it is skipped.
+     *
+     * @var array<non-empty-string,non-empty-string>
+     */
+    protected array $skippedTests = [];
+
+    protected ?CacheItemPoolInterface $cache;
 
     protected function setUp(): void
     {
@@ -28,6 +54,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends CachePoolTest
         // set non-UTC timezone
         $this->tz = date_default_timezone_get();
         date_default_timezone_set('America/Vancouver');
+        $this->cache = $this->createCachePool();
     }
 
     protected function tearDown(): void
@@ -38,6 +65,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends CachePoolTest
 
         if ($this->storage instanceof FlushableInterface) {
             $this->storage->flush();
+            $this->cache->clear();
         }
 
         parent::tearDown();
@@ -55,5 +83,928 @@ abstract class AbstractCacheItemPoolIntegrationTest extends CachePoolTest
     {
         $this->storage = $this->createStorage();
         return new CacheItemPoolDecorator($this->storage);
+    }
+
+    /**
+     * Data provider for invalid keys.
+     *
+     * @return list<array{0:mixed}>
+     */
+    public static function invalidKeys(): array
+    {
+        return [
+            [true],
+            [false],
+            [null],
+            [2],
+            [2.5],
+            ['{str'],
+            ['rand{'],
+            ['rand{str'],
+            ['rand}str'],
+            ['rand(str'],
+            ['rand)str'],
+            ['rand/str'],
+            ['rand\\str'],
+            ['rand@str'],
+            ['rand:str'],
+            [new stdClass()],
+            [['array']],
+        ];
+    }
+
+    public function testBasicUsage(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('4711');
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key2');
+        $item->set('4712');
+        $this->cache->save($item);
+
+        $fooItem = $this->cache->getItem('key');
+        self::assertTrue($fooItem->isHit());
+        self::assertEquals('4711', $fooItem->get());
+
+        $barItem = $this->cache->getItem('key2');
+        self::assertTrue($barItem->isHit());
+        self::assertEquals('4712', $barItem->get());
+
+        // Remove 'key' and make sure 'key2' is still there
+        $this->cache->deleteItem('key');
+        self::assertFalse($this->cache->getItem('key')->isHit());
+        self::assertTrue($this->cache->getItem('key2')->isHit());
+
+        // Remove everything
+        $this->cache->clear();
+        self::assertFalse($this->cache->getItem('key')->isHit());
+        self::assertFalse($this->cache->getItem('key2')->isHit());
+    }
+
+    public function testBasicUsageWithLongKey(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $pool = $this->createCachePool();
+
+        $key = str_repeat('a', 300);
+
+        $item = $pool->getItem($key);
+        self::assertFalse($item->isHit());
+        self::assertSame($key, $item->getKey());
+
+        $item->set('value');
+        self::assertTrue($pool->save($item));
+
+        $item = $pool->getItem($key);
+        self::assertTrue($item->isHit());
+        self::assertSame($key, $item->getKey());
+        self::assertSame('value', $item->get());
+
+        self::assertTrue($pool->deleteItem($key));
+
+        $item = $pool->getItem($key);
+        self::assertFalse($item->isHit());
+    }
+
+    public function testItemModifiersReturnsStatic(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        self::assertSame($item, $item->set('4711'));
+        self::assertSame($item, $item->expiresAfter(2));
+        self::assertSame($item, $item->expiresAt(new DateTimeImmutable('+2hours')));
+    }
+
+    public function testGetItem(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->save($item);
+
+        // get existing item
+        $item = $this->cache->getItem('key');
+        self::assertEquals('value', $item->get(), 'A stored item must be returned from cached.');
+        self::assertEquals('key', $item->getKey(), 'Cache key can not change.');
+
+        // get non-existent item
+        $item = $this->cache->getItem('key2');
+        self::assertFalse($item->isHit());
+        self::assertNull($item->get(), "Item's value must be null when isHit is false.");
+    }
+
+    public function testGetItems(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $keys = ['foo', 'bar', 'baz'];
+        /** @var array<non-empty-string,CacheItemInterface> $items */
+        $items = $this->cache->getItems($keys);
+
+        $count = 0;
+
+        foreach ($items as $i => $item) {
+            $item->set($i);
+            $this->cache->save($item);
+
+            $count++;
+        }
+
+        self::assertSame(3, $count);
+
+        $keys[] = 'biz';
+        /** @var array<non-empty-string,CacheItemInterface> $items */
+        $items = $this->cache->getItems($keys);
+        $count = 0;
+        foreach ($items as $key => $item) {
+            $itemKey = $item->getKey();
+            self::assertEquals($itemKey, $key, 'Keys must be preserved when fetching multiple items');
+            self::assertEquals($key !== 'biz', $item->isHit());
+            self::assertTrue(in_array($key, $keys), 'Cache key can not change.');
+
+            // Remove $key for $keys
+            foreach ($keys as $k => $v) {
+                if ($v === $key) {
+                    unset($keys[$k]);
+                }
+            }
+
+            $count++;
+        }
+
+        self::assertSame(4, $count);
+    }
+
+    public function testGetItemsEmpty(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $items = $this->cache->getItems([]);
+        self::assertTrue(
+            is_array($items) || $items instanceof Traversable,
+            'A call to getItems with an empty array must always return an array or \Traversable.'
+        );
+
+        $count = count(is_array($items) ? $items : iterator_to_array($items));
+
+        self::assertSame(0, $count);
+    }
+
+    public function testHasItem(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->save($item);
+
+        // has existing item
+        self::assertTrue($this->cache->hasItem('key'));
+
+        // has non-existent item
+        self::assertFalse($this->cache->hasItem('key2'));
+    }
+
+    public function testClear(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->save($item);
+
+        $return = $this->cache->clear();
+
+        self::assertTrue($return, 'clear() must return true if cache was cleared. ');
+        self::assertFalse(
+            $this->cache->getItem('key')->isHit(),
+            'No item should be a hit after the cache is cleared. '
+        );
+        self::assertFalse(
+            $this->cache->hasItem('key2'),
+            'The cache pool should be empty after it is cleared.'
+        );
+    }
+
+    public function testClearWithDeferredItems(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->saveDeferred($item);
+
+        $this->cache->clear();
+        $this->cache->commit();
+
+        self::assertFalse(
+            $this->cache->getItem('key')->isHit(),
+            'Deferred items must be cleared on clear().'
+        );
+    }
+
+    public function testDeleteItem(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->save($item);
+
+        self::assertTrue($this->cache->deleteItem('key'));
+        self::assertFalse(
+            $this->cache->getItem('key')->isHit(),
+            'A deleted item should not be a hit.'
+        );
+        self::assertFalse(
+            $this->cache->hasItem('key'),
+            'A deleted item should not be a in cache.'
+        );
+
+        self::assertTrue(
+            $this->cache->deleteItem('key2'),
+            'Deleting an item that does not exist should return true.'
+        );
+    }
+
+    public function testDeleteItems(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        /** @var array<non-empty-string,CacheItemInterface> $items */
+        $items = $this->cache->getItems(['foo', 'bar', 'baz']);
+
+        foreach ($items as $idx => $item) {
+            $item->set($idx);
+            $this->cache->save($item);
+        }
+
+        // All should be a hit but 'biz'
+        self::assertTrue($this->cache->getItem('foo')->isHit());
+        self::assertTrue($this->cache->getItem('bar')->isHit());
+        self::assertTrue($this->cache->getItem('baz')->isHit());
+        self::assertFalse($this->cache->getItem('biz')->isHit());
+
+        $return = $this->cache->deleteItems(['foo', 'bar', 'biz']);
+        self::assertTrue($return);
+
+        self::assertFalse($this->cache->getItem('foo')->isHit());
+        self::assertFalse($this->cache->getItem('bar')->isHit());
+        self::assertTrue($this->cache->getItem('baz')->isHit());
+        self::assertFalse($this->cache->getItem('biz')->isHit());
+    }
+
+    public function testSave(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $return = $this->cache->save($item);
+
+        self::assertTrue($return, 'save() should return true when items are saved.');
+        self::assertEquals('value', $this->cache->getItem('key')->get());
+    }
+
+    public function testSaveExpired(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $item->expiresAt(DateTimeImmutable::createFromFormat('U', (string) (time() + 10)));
+        $this->cache->save($item);
+        $item->expiresAt(DateTimeImmutable::createFromFormat('U', (string) (time() - 1)));
+        $this->cache->save($item);
+        $item = $this->cache->getItem('key');
+        self::assertFalse($item->isHit(), 'Cache should not save expired items');
+    }
+
+    public function testSaveWithoutExpire(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('test_ttl_null');
+        $item->set('data');
+        $this->cache->save($item);
+
+        // Use a new pool instance to ensure that we don't hit any caches
+        $pool = $this->createCachePool();
+        $item = $pool->getItem('test_ttl_null');
+
+        self::assertTrue($item->isHit(), 'Cache should have retrieved the items');
+        self::assertEquals('data', $item->get());
+    }
+
+    public function testDeferredSave(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('4711');
+        $return = $this->cache->saveDeferred($item);
+        self::assertTrue($return, 'save() should return true when items are saved.');
+
+        $item = $this->cache->getItem('key2');
+        $item->set('4712');
+        $this->cache->saveDeferred($item);
+
+        // They are not saved yet but should be a hit
+        self::assertTrue(
+            $this->cache->hasItem('key'),
+            'Deferred items should be considered as a part of the cache even before they are committed'
+        );
+        self::assertTrue(
+            $this->cache->getItem('key')->isHit(),
+            'Deferred items should be a hit even before they are committed'
+        );
+        self::assertTrue($this->cache->getItem('key2')->isHit());
+
+        $this->cache->commit();
+
+        // They should be a hit after the commit as well
+        self::assertTrue($this->cache->getItem('key')->isHit());
+        self::assertTrue($this->cache->getItem('key2')->isHit());
+    }
+
+    public function testDeferredExpired(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('4711');
+        $item->expiresAt(DateTimeImmutable::createFromFormat('U', time() - 1));
+        $this->cache->saveDeferred($item);
+
+        self::assertFalse(
+            $this->cache->hasItem('key'),
+            'Cache should not have expired deferred item'
+        );
+        $this->cache->commit();
+        $item = $this->cache->getItem('key');
+        self::assertFalse($item->isHit(), 'Cache should not save expired items');
+    }
+
+    public function testDeleteDeferredItem(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('4711');
+        $this->cache->saveDeferred($item);
+        self::assertTrue($this->cache->getItem('key')->isHit());
+
+        $this->cache->deleteItem('key');
+        self::assertFalse(
+            $this->cache->hasItem('key'),
+            'You must be able to delete a deferred item before committed.'
+        );
+        self::assertFalse(
+            $this->cache->getItem('key')->isHit(),
+            'You must be able to delete a deferred item before committed.'
+        );
+
+        $this->cache->commit();
+        self::assertFalse(
+            $this->cache->hasItem('key'),
+            'A deleted item should not reappear after commit.'
+        );
+        self::assertFalse(
+            $this->cache->getItem('key')->isHit(),
+            'A deleted item should not reappear after commit.'
+        );
+    }
+
+    public function testDeferredSaveWithoutCommit(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->prepareDeferredSaveWithoutCommit();
+        gc_collect_cycles();
+
+        $cache = $this->createCachePool();
+        self::assertTrue(
+            $cache->getItem('key')->isHit(),
+            'A deferred item should automatically be committed on CachePool::__destruct().'
+        );
+    }
+
+    private function prepareDeferredSaveWithoutCommit(): void
+    {
+        $cache       = $this->cache;
+        $this->cache = null;
+        $item        = $cache->getItem('key');
+        $item->set('4711');
+        $cache->saveDeferred($item);
+    }
+
+    public function testCommit(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->saveDeferred($item);
+        $return = $this->cache->commit();
+
+        self::assertTrue($return, 'commit() should return true on successful commit. ');
+        self::assertEquals('value', $this->cache->getItem('key')->get());
+
+        $return = $this->cache->commit();
+        self::assertTrue(
+            $return,
+            'commit() should return true even if no items were deferred.'
+        );
+    }
+
+    /**
+     * @medium
+     */
+    public function testExpiration(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $item->expiresAfter(2);
+        $this->cache->save($item);
+
+        sleep(3);
+        $item = $this->cache->getItem('key');
+        self::assertFalse($item->isHit());
+        self::assertNull($item->get(), "Item's value must be null when isHit() is false.");
+    }
+
+    public function testExpiresAt(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $item->expiresAt(new DateTimeImmutable('+2hours'));
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue($item->isHit());
+    }
+
+    public function testExpiresAtWithNull(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $item->expiresAt(null);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue($item->isHit());
+    }
+
+    public function testExpiresAfterWithNull(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $item->expiresAfter(null);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue($item->isHit());
+    }
+
+    public function testKeyLength(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $key  = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.';
+        $item = $this->cache->getItem($key);
+        $item->set('value');
+        self::assertTrue(
+            $this->cache->save($item),
+            'The implementation does not support a valid cache key'
+        );
+
+        self::assertTrue($this->cache->hasItem($key));
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testGetItemInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->getItem($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testGetItemsInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->getItems(['key1', $key, 'key2']);
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testHasItemInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->hasItem($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testDeleteItemInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->deleteItem($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testDeleteItemsInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->deleteItems(['key1', $key, 'key2']);
+    }
+
+    public function testDataTypeString(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('5');
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue(
+            '5' === $item->get(),
+            'Wrong data type. If we store a string we must get an string back.'
+        );
+        self::assertTrue(
+            is_string($item->get()),
+            'Wrong data type. If we store a string we must get an string back.'
+        );
+    }
+
+    public function testDataTypeInteger(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set(5);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue(
+            5 === $item->get(),
+            'Wrong data type. If we store an int we must get an int back.'
+        );
+        self::assertTrue(
+            is_int($item->get()),
+            'Wrong data type. If we store an int we must get an int back.'
+        );
+    }
+
+    public function testDataTypeNull(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set(null);
+        $this->cache->save($item);
+
+        self::assertTrue(
+            $this->cache->hasItem('key'),
+            'Null is a perfectly fine cache value. hasItem() should return true when null are stored.'
+        );
+        $item = $this->cache->getItem('key');
+        self::assertTrue(
+            null === $item->get(),
+            'Wrong data type. If we store null we must get an null back.'
+        );
+        self::assertTrue(
+            $item->isHit(),
+            'isHit() should return true when null are stored.'
+        );
+    }
+
+    public function testDataTypeFloat(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $float = 1.23456789;
+        $item  = $this->cache->getItem('key');
+        $item->set($float);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue(
+            is_float($item->get()),
+            'Wrong data type. If we store float we must get an float back.'
+        );
+        self::assertEquals($float, $item->get());
+        self::assertTrue(
+            $item->isHit(),
+            'isHit() should return true when float are stored.'
+        );
+    }
+
+    public function testDataTypeBoolean(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set(true);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue(
+            is_bool($item->get()),
+            'Wrong data type. If we store boolean we must get an boolean back.'
+        );
+        self::assertTrue($item->get());
+        self::assertTrue(
+            $item->isHit(),
+            'isHit() should return true when true are stored.'
+        );
+    }
+
+    public function testDataTypeArray(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $array = ['a' => 'foo', 2 => 'bar'];
+        $item  = $this->cache->getItem('key');
+        $item->set($array);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue(
+            is_array($item->get()),
+            'Wrong data type. If we store array we must get an array back.'
+        );
+        self::assertEquals($array, $item->get());
+        self::assertTrue(
+            $item->isHit(),
+            'isHit() should return true when array are stored.'
+        );
+    }
+
+    public function testDataTypeObject(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $object    = new stdClass();
+        $object->a = 'foo';
+        $item      = $this->cache->getItem('key');
+        $item->set($object);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue(
+            is_object($item->get()),
+            'Wrong data type. If we store object we must get an object back.'
+        );
+        self::assertEquals($object, $item->get());
+        self::assertTrue(
+            $item->isHit(),
+            'isHit() should return true when object are stored.'
+        );
+    }
+
+    public function testBinaryData(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $data = '';
+        for ($i = 0; $i < 256; $i++) {
+            $data .= chr($i);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set($data);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue($data === $item->get(), 'Binary data must survive a round trip.');
+    }
+
+    public function testIsHit(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertTrue($item->isHit());
+    }
+
+    public function testIsHitDeferred(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->saveDeferred($item);
+
+        // Test accessing the value before it is committed
+        $item = $this->cache->getItem('key');
+        self::assertTrue($item->isHit());
+
+        $this->cache->commit();
+        $item = $this->cache->getItem('key');
+        self::assertTrue($item->isHit());
+    }
+
+    public function testSaveDeferredWhenChangingValues(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->saveDeferred($item);
+
+        $item = $this->cache->getItem('key');
+        $item->set('new value');
+
+        $item = $this->cache->getItem('key');
+        self::assertEquals(
+            'value',
+            $item->get(),
+            'Items that is put in the deferred queue should not get their values changed'
+        );
+
+        $this->cache->commit();
+        $item = $this->cache->getItem('key');
+        self::assertEquals(
+            'value',
+            $item->get(),
+            'Items that is put in the deferred queue should not get their values changed'
+        );
+    }
+
+    public function testSaveDeferredOverwrite(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $this->cache->saveDeferred($item);
+
+        $item = $this->cache->getItem('key');
+        $item->set('new value');
+        $this->cache->saveDeferred($item);
+
+        $item = $this->cache->getItem('key');
+        self::assertEquals('new value', $item->get());
+
+        $this->cache->commit();
+        $item = $this->cache->getItem('key');
+        self::assertEquals('new value', $item->get());
+    }
+
+    public function testSavingObject(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set(new DateTimeImmutable());
+        $this->cache->save($item);
+
+        $item  = $this->cache->getItem('key');
+        $value = $item->get();
+        self::assertInstanceOf(DateTimeImmutable::class, $value, 'You must be able to store objects in cache.');
+    }
+
+    /**
+     * @medium
+     */
+    public function testHasItemReturnsFalseWhenDeferredItemIsExpired(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $item->expiresAfter(2);
+        $this->cache->saveDeferred($item);
+
+        sleep(3);
+        self::assertFalse($this->cache->hasItem('key'));
     }
 }

--- a/src/AbstractCacheItemPoolIntegrationTest.php
+++ b/src/AbstractCacheItemPoolIntegrationTest.php
@@ -65,6 +65,9 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
 
         if ($this->storage instanceof FlushableInterface) {
             $this->storage->flush();
+        }
+
+        if ($this->cache !== null) {
             $this->cache->clear();
         }
 

--- a/src/AbstractCacheItemPoolIntegrationTest.php
+++ b/src/AbstractCacheItemPoolIntegrationTest.php
@@ -471,7 +471,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
 
         $item = $this->cache->getItem('key');
         $item->set('4711');
-        $item->expiresAt(DateTimeImmutable::createFromFormat('U', time() - 1));
+        $item->expiresAt(DateTimeImmutable::createFromFormat('U', (string) (time() - 1)));
         $this->cache->saveDeferred($item);
 
         self::assertFalse(

--- a/src/AbstractSimpleCacheIntegrationTest.php
+++ b/src/AbstractSimpleCacheIntegrationTest.php
@@ -4,23 +4,45 @@ declare(strict_types=1);
 
 namespace LaminasTest\Cache\Storage\Adapter;
 
-use Cache\IntegrationTests\SimpleCacheTest;
+use DateInterval;
+use Generator;
 use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+use stdClass;
 
+use function array_merge;
+use function chr;
 use function date_default_timezone_get;
 use function date_default_timezone_set;
 use function get_class;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+use function sleep;
+use function sort;
+use function str_repeat;
 
-abstract class AbstractSimpleCacheIntegrationTest extends SimpleCacheTest
+abstract class AbstractSimpleCacheIntegrationTest extends TestCase
 {
-    /** @var string|null  */
-    private $tz;
+    private ?string $tz = null;
 
-    /** @var StorageInterface|null */
-    private $storage;
+    private ?StorageInterface $storage = null;
+
+    /**
+     * Map of test name and the reason why it is skipped.
+     *
+     * @var array<non-empty-string,non-empty-string>
+     */
+    protected array $skippedTests = [];
+
+    protected CacheInterface $cache;
 
     protected function setUp(): void
     {
@@ -28,6 +50,7 @@ abstract class AbstractSimpleCacheIntegrationTest extends SimpleCacheTest
         // set non-UTC timezone
         $this->tz = date_default_timezone_get();
         date_default_timezone_set('America/Vancouver');
+        $this->cache = $this->createSimpleCache();
     }
 
     protected function tearDown(): void
@@ -39,6 +62,7 @@ abstract class AbstractSimpleCacheIntegrationTest extends SimpleCacheTest
 
         if ($this->storage instanceof FlushableInterface) {
             $this->storage->flush();
+            $this->cache->clear();
         }
     }
 
@@ -54,5 +78,757 @@ abstract class AbstractSimpleCacheIntegrationTest extends SimpleCacheTest
     {
         $this->storage = $this->createStorage();
         return new SimpleCacheDecorator($this->storage);
+    }
+
+    /**
+     * Advance time perceived by the cache for the purposes of testing TTL.
+     *
+     * The default implementation sleeps for the specified duration,
+     * but subclasses are encouraged to override this,
+     * adjusting a mocked time possibly set up in {@link createSimpleCache()},
+     * to speed up the tests.
+     *
+     * @param 0|positive-int $seconds
+     */
+    protected function advanceTime(int $seconds): void
+    {
+        sleep($seconds);
+    }
+
+    /**
+     * Data provider for invalid cache keys.
+     *
+     * @return list<array{0:mixed}>
+     */
+    public static function invalidKeys(): array
+    {
+        return array_merge(
+            self::invalidArrayKeys(),
+            [
+                [2],
+            ]
+        );
+    }
+
+    /**
+     * Data provider for invalid array keys.
+     *
+     * @return list<array{0:mixed}>
+     */
+    public static function invalidArrayKeys(): array
+    {
+        return [
+            [''],
+            [true],
+            [false],
+            [null],
+            [2.5],
+            ['{str'],
+            ['rand{'],
+            ['rand{str'],
+            ['rand}str'],
+            ['rand(str'],
+            ['rand)str'],
+            ['rand/str'],
+            ['rand\\str'],
+            ['rand@str'],
+            ['rand:str'],
+            [new stdClass()],
+            [['array']],
+        ];
+    }
+
+    /**
+     * @return list<array{0:mixed}>
+     */
+    public static function invalidTtl(): array
+    {
+        return [
+            [''],
+            [true],
+            [false],
+            ['abc'],
+            [2.5],
+            [' 1'], // can be casted to a int
+            ['12foo'], // can be casted to a int
+            ['025'], // can be interpreted as hex
+            [new stdClass()],
+            [['array']],
+        ];
+    }
+
+    /**
+     * Data provider for valid keys.
+     *
+     * @return list<array{0:non-empty-string}>
+     */
+    public static function validKeys(): array
+    {
+        return [
+            ['AbC19_.'],
+            ['1234567890123456789012345678901234567890123456789012345678901234'],
+        ];
+    }
+
+    /**
+     * Data provider for valid data to store.
+     *
+     * @return list<array{0:mixed}>
+     */
+    public static function validData(): array
+    {
+        return [
+            ['AbC19_.'],
+            [4711],
+            [47.11],
+            [true],
+            [null],
+            [['key' => 'value']],
+            [new stdClass()],
+        ];
+    }
+
+    public function testSet(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $result = $this->cache->set('key', 'value');
+        self::assertTrue($result, 'set() must return true if success');
+        self::assertEquals('value', $this->cache->get('key'));
+    }
+
+    /**
+     * @medium
+     */
+    public function testSetTtl(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $result = $this->cache->set('key1', 'value', 2);
+        self::assertTrue($result, 'set() must return true if success');
+        self::assertEquals('value', $this->cache->get('key1'));
+
+        $this->cache->set('key2', 'value', new DateInterval('PT2S'));
+        self::assertEquals('value', $this->cache->get('key2'));
+
+        $this->advanceTime(3);
+
+        self::assertNull($this->cache->get('key1'), 'Value must expire after ttl.');
+        self::assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
+    }
+
+    public function testSetExpiredTtl(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->set('key0', 'value');
+        $this->cache->set('key0', 'value', 0);
+        self::assertNull($this->cache->get('key0'));
+        self::assertFalse($this->cache->has('key0'));
+
+        $this->cache->set('key1', 'value', -1);
+        self::assertNull($this->cache->get('key1'));
+        self::assertFalse($this->cache->has('key1'));
+    }
+
+    public function testGet(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        self::assertNull($this->cache->get('key'));
+        self::assertEquals('foo', $this->cache->get('key', 'foo'));
+
+        $this->cache->set('key', 'value');
+        self::assertEquals('value', $this->cache->get('key', 'foo'));
+    }
+
+    public function testDelete(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        self::assertTrue($this->cache->delete('key'), 'Deleting a value that does not exist should return true');
+        $this->cache->set('key', 'value');
+        self::assertTrue($this->cache->delete('key'), 'Delete must return true on success');
+        self::assertNull($this->cache->get('key'), 'Values must be deleted on delete()');
+    }
+
+    public function testClear(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        self::assertTrue($this->cache->clear(), 'Clearing an empty cache should return true');
+        $this->cache->set('key', 'value');
+        self::assertTrue($this->cache->clear(), 'Delete must return true on success');
+        self::assertNull($this->cache->get('key'), 'Values must be deleted on clear()');
+    }
+
+    public function testSetMultiple(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $result = $this->cache->setMultiple(['key0' => 'value0', 'key1' => 'value1']);
+        self::assertTrue($result, 'setMultiple() must return true if success');
+        self::assertEquals('value0', $this->cache->get('key0'));
+        self::assertEquals('value1', $this->cache->get('key1'));
+    }
+
+    public function testSetMultipleWithIntegerArrayKey(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $result = $this->cache->setMultiple(['0' => 'value0']);
+        self::assertTrue($result, 'setMultiple() must return true if success');
+        self::assertEquals('value0', $this->cache->get('0'));
+    }
+
+    /**
+     * @medium
+     */
+    public function testSetMultipleTtl(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->setMultiple(['key2' => 'value2', 'key3' => 'value3'], 2);
+        self::assertEquals('value2', $this->cache->get('key2'));
+        self::assertEquals('value3', $this->cache->get('key3'));
+
+        $this->cache->setMultiple(['key4' => 'value4'], new DateInterval('PT2S'));
+        self::assertEquals('value4', $this->cache->get('key4'));
+
+        $this->advanceTime(3);
+        self::assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
+        self::assertNull($this->cache->get('key3'), 'Value must expire after ttl.');
+        self::assertNull($this->cache->get('key4'), 'Value must expire after ttl.');
+    }
+
+    public function testSetMultipleExpiredTtl(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->setMultiple(['key0' => 'value0', 'key1' => 'value1'], 0);
+        self::assertNull($this->cache->get('key0'));
+        self::assertNull($this->cache->get('key1'));
+    }
+
+    public function testSetMultipleWithGenerator(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $gen = function (): Generator {
+            yield 'key0' => 'value0';
+            yield 'key1' => 'value1';
+        };
+
+        $this->cache->setMultiple($gen());
+        self::assertEquals('value0', $this->cache->get('key0'));
+        self::assertEquals('value1', $this->cache->get('key1'));
+    }
+
+    public function testGetMultiple(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $result = $this->cache->getMultiple(['key0', 'key1']);
+        $keys   = [];
+        foreach ($result as $i => $r) {
+            $keys[] = $i;
+            self::assertNull($r);
+        }
+        sort($keys);
+        self::assertSame(['key0', 'key1'], $keys);
+
+        $this->cache->set('key3', 'value');
+        $result = $this->cache->getMultiple(['key2', 'key3', 'key4'], 'foo');
+        $keys   = [];
+        foreach ($result as $key => $r) {
+            $keys[] = $key;
+            if ($key === 'key3') {
+                self::assertEquals('value', $r);
+            } else {
+                self::assertEquals('foo', $r);
+            }
+        }
+        sort($keys);
+        self::assertSame(['key2', 'key3', 'key4'], $keys);
+    }
+
+    public function testGetMultipleWithGenerator(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $gen = function (): Generator {
+            yield 1 => 'key0';
+            yield 1 => 'key1';
+        };
+
+        $this->cache->set('key0', 'value0');
+        $result = $this->cache->getMultiple($gen());
+        $keys   = [];
+        foreach ($result as $key => $r) {
+            $keys[] = $key;
+            if ($key === 'key0') {
+                self::assertEquals('value0', $r);
+            } elseif ($key === 'key1') {
+                self::assertNull($r);
+            } else {
+                self::assertFalse(true, 'This should not happend');
+            }
+        }
+        sort($keys);
+        self::assertSame(['key0', 'key1'], $keys);
+        self::assertEquals('value0', $this->cache->get('key0'));
+        self::assertNull($this->cache->get('key1'));
+    }
+
+    public function testDeleteMultiple(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        self::assertTrue($this->cache->deleteMultiple([]), 'Deleting a empty array should return true');
+        self::assertTrue(
+            $this->cache->deleteMultiple(['key']),
+            'Deleting a value that does not exist should return true'
+        );
+
+        $this->cache->set('key0', 'value0');
+        $this->cache->set('key1', 'value1');
+        self::assertTrue($this->cache->deleteMultiple(['key0', 'key1']), 'Delete must return true on success');
+        self::assertNull($this->cache->get('key0'), 'Values must be deleted on deleteMultiple()');
+        self::assertNull($this->cache->get('key1'), 'Values must be deleted on deleteMultiple()');
+    }
+
+    public function testDeleteMultipleGenerator(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $gen = function (): Generator {
+            yield 1 => 'key0';
+            yield 1 => 'key1';
+        };
+        $this->cache->set('key0', 'value0');
+        self::assertTrue($this->cache->deleteMultiple($gen()), 'Deleting a generator should return true');
+
+        self::assertNull($this->cache->get('key0'), 'Values must be deleted on deleteMultiple()');
+        self::assertNull($this->cache->get('key1'), 'Values must be deleted on deleteMultiple()');
+    }
+
+    public function testHas(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        self::assertFalse($this->cache->has('key0'));
+        $this->cache->set('key0', 'value0');
+        self::assertTrue($this->cache->has('key0'));
+    }
+
+    public function testBasicUsageWithLongKey(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $key = str_repeat('a', 300);
+
+        self::assertFalse($this->cache->has($key));
+        self::assertTrue($this->cache->set($key, 'value'));
+
+        self::assertTrue($this->cache->has($key));
+        self::assertSame('value', $this->cache->get($key));
+
+        self::assertTrue($this->cache->delete($key));
+
+        self::assertFalse($this->cache->has($key));
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testGetInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->get($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testGetMultipleInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->getMultiple(['key1', $key, 'key2']);
+    }
+
+    public function testGetMultipleNoIterable(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->getMultiple('key');
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testSetInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->set($key, 'foobar');
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidArrayKeys
+     */
+    public function testSetMultipleInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $values = function () use ($key): Generator {
+            yield 'key1' => 'foo';
+            yield $key => 'bar';
+            yield 'key2' => 'baz';
+        };
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->setMultiple($values());
+    }
+
+    public function testSetMultipleNoIterable(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->setMultiple('key');
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testHasInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->has($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testDeleteInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->delete($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @dataProvider invalidKeys
+     */
+    public function testDeleteMultipleInvalidKeys($key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->deleteMultiple(['key1', $key, 'key2']);
+    }
+
+    public function testDeleteMultipleNoIterable(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->deleteMultiple('key');
+    }
+
+    /**
+     * @param mixed $ttl
+     * @dataProvider invalidTtl
+     */
+    public function testSetInvalidTtl($ttl): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->set('key', 'value', $ttl);
+    }
+
+    /**
+     * @param mixed $ttl
+     * @dataProvider invalidTtl
+     */
+    public function testSetMultipleInvalidTtl($ttl): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->cache->setMultiple(['key' => 'value'], $ttl);
+    }
+
+    public function testNullOverwrite(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->set('key', 5);
+        $this->cache->set('key', null);
+
+        self::assertNull($this->cache->get('key'), 'Setting null to a key must overwrite previous value');
+    }
+
+    public function testDataTypeString(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->set('key', '5');
+        $result = $this->cache->get('key');
+        self::assertTrue('5' === $result, 'Wrong data type. If we store a string we must get an string back.');
+        self::assertTrue(is_string($result), 'Wrong data type. If we store a string we must get an string back.');
+    }
+
+    public function testDataTypeInteger(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->set('key', 5);
+        $result = $this->cache->get('key');
+        self::assertTrue(5 === $result, 'Wrong data type. If we store an int we must get an int back.');
+        self::assertTrue(is_int($result), 'Wrong data type. If we store an int we must get an int back.');
+    }
+
+    public function testDataTypeFloat(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $float = 1.23456789;
+        $this->cache->set('key', $float);
+        $result = $this->cache->get('key');
+        self::assertTrue(is_float($result), 'Wrong data type. If we store float we must get an float back.');
+        self::assertEquals($float, $result);
+    }
+
+    public function testDataTypeBoolean(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->set('key', false);
+        $result = $this->cache->get('key');
+        self::assertTrue(is_bool($result), 'Wrong data type. If we store boolean we must get an boolean back.');
+        self::assertFalse($result);
+        self::assertTrue($this->cache->has('key'), 'has() should return true when true are stored. ');
+    }
+
+    public function testDataTypeArray(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $array = ['a' => 'foo', 2 => 'bar'];
+        $this->cache->set('key', $array);
+        $result = $this->cache->get('key');
+        self::assertTrue(is_array($result), 'Wrong data type. If we store array we must get an array back.');
+        self::assertEquals($array, $result);
+    }
+
+    public function testDataTypeObject(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $object    = new stdClass();
+        $object->a = 'foo';
+        $this->cache->set('key', $object);
+        $result = $this->cache->get('key');
+        self::assertTrue(is_object($result), 'Wrong data type. If we store object we must get an object back.');
+        self::assertEquals($object, $result);
+    }
+
+    public function testBinaryData(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $data = '';
+        for ($i = 0; $i < 256; $i++) {
+            $data .= chr($i);
+        }
+
+        $this->cache->set('key', $data);
+        $result = $this->cache->get('key');
+        self::assertTrue($data === $result, 'Binary data must survive a round trip.');
+    }
+
+    /**
+     * @dataProvider validKeys
+     */
+    public function testSetValidKeys(string $key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->set($key, 'foobar');
+        self::assertEquals('foobar', $this->cache->get($key));
+    }
+
+    /**
+     * @dataProvider validKeys
+     */
+    public function testSetMultipleValidKeys(string $key): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->setMultiple([$key => 'foobar']);
+        $result = $this->cache->getMultiple([$key]);
+        $keys   = [];
+        foreach ($result as $i => $r) {
+            $keys[] = $i;
+            self::assertEquals($key, $i);
+            self::assertEquals('foobar', $r);
+        }
+        self::assertSame([$key], $keys);
+    }
+
+    /**
+     * @param mixed $data
+     * @dataProvider validData
+     */
+    public function testSetValidData($data): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->set('key', $data);
+        self::assertEquals($data, $this->cache->get('key'));
+    }
+
+    /**
+     * @param mixed $data
+     * @dataProvider validData
+     */
+    public function testSetMultipleValidData($data): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $this->cache->setMultiple(['key' => $data]);
+        $result = $this->cache->getMultiple(['key']);
+        $keys   = [];
+        foreach ($result as $i => $r) {
+            $keys[] = $i;
+            self::assertEquals($data, $r);
+        }
+        self::assertSame(['key'], $keys);
+    }
+
+    public function testObjectAsDefaultValue(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $obj      = new stdClass();
+        $obj->foo = 'value';
+        self::assertEquals($obj, $this->cache->get('key', $obj));
+    }
+
+    public function testObjectDoesNotChangeInCache(): void
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $obj      = new stdClass();
+        $obj->foo = 'value';
+        $this->cache->set('key', $obj);
+        $obj->foo = 'changed';
+
+        $cacheObject = $this->cache->get('key');
+        self::assertIsObject($cacheObject);
+        self::assertEquals('value', $cacheObject->foo, 'Object in cache should not have their values changed.');
     }
 }

--- a/test/integration/CacheItemPoolIntegrationTestTest.php
+++ b/test/integration/CacheItemPoolIntegrationTestTest.php
@@ -12,7 +12,6 @@ final class CacheItemPoolIntegrationTestTest extends AbstractCacheItemPoolIntegr
 {
     protected function setUp(): void
     {
-        /** @psalm-suppress MixedArrayAssignment `cache/integration-tests` type annotation is not appropriate here. */
         $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired']
             = 'Skipping since laminas-cache does not yet handle `expiresAt` properly.'
             . ' See https://github.com/laminas/laminas-cache/pull/199';


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This also removes the runtime `class_alias` for ancient phpunit versions which are not supported by this component anyways.
These `class_alias` were used for an old version of `cache/integration-tests` which supported ancient PHP & PHPUnit versions.

By moving the integration test cases to this component, several type-additions were made.

This PR also removes compatibility to PHP 7.3 and therefore, the new minimum required PHP version will be PHP 7.4.

----

This also allows the installation in upstream cache adapters properly as they do not allow the `dev-master` branch for the `cache/integration-tests` dependency anymore. Since they did not tagged a release within 2 years, I don't expect a new version anyways. I've starred the repository for keeping track of new integration tests.