### PR TITLE
Make data provider static as required by phpunit 10+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
+        "composer-plugin-api": "^2",
         "laminas/laminas-cache": "4.0.x-dev || ^4.0",
         "laminas/laminas-coding-standard": "~2.5.0",
         "psalm/plugin-phpunit": "^0.19.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "748d85ada33757318dc473f4ac4e4dfd",
+    "content-hash": "2a7348a5e3d2290b82f8403343a499a2",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -4554,7 +4554,9 @@
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "composer-plugin-api": "^2"
+    },
     "platform-overrides": {
         "php": "8.1.99"
     },

--- a/src/PluginManagerDelegatorFactoryTestTrait.php
+++ b/src/PluginManagerDelegatorFactoryTestTrait.php
@@ -20,7 +20,7 @@ trait PluginManagerDelegatorFactoryTestTrait
      *
      * @psalm-return iterable<non-empty-string,array{0:non-empty-string}>
      */
-    abstract public function getCommonAdapterNamesProvider(): iterable;
+    abstract public static function getCommonAdapterNamesProvider(): iterable;
 
     /**
      * Should provide the provisioned plugin manager.

--- a/test/integration/AdapterForIntegrationTestDetector.php
+++ b/test/integration/AdapterForIntegrationTestDetector.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTestTest\Cache\Storage\Adapter;
+
+use Composer\InstalledVersions;
+use Laminas\Cache\Exception\RuntimeException;
+use Laminas\Cache\Storage\Adapter\Apcu;
+use Laminas\Cache\Storage\Adapter\Memory;
+use Laminas\Cache\Storage\StorageInterface;
+
+use function assert;
+use function class_exists;
+use function is_a;
+
+final class AdapterForIntegrationTestDetector
+{
+    /**
+     * @psalm-suppress MixedInferredReturnType Due to recursive dependencies, we can not have APCu installed as during
+     *                                         development. Will be installed during CI via `.laminas-ci.json`.
+     */
+    public static function detect(): StorageInterface
+    {
+        if (InstalledVersions::isInstalled('laminas/laminas-cache-storage-adapter-apcu')) {
+            assert(class_exists(Apcu::class));
+            assert(is_a(Apcu::class, StorageInterface::class));
+            /**
+             * @psalm-suppress MixedReturnStatement Due to recursive dependencies, we can not have APCu installed as
+             *                                        during development. Will be installed during CI via
+             *                                        `.laminas-ci.json`.
+             */
+            return new Apcu();
+        }
+
+        if (InstalledVersions::isInstalled('laminas/laminas-cache-storage-adapter-memory')) {
+            assert(class_exists(Memory::class));
+            assert(is_a(Memory::class, StorageInterface::class));
+            /**
+             * @psalm-suppress MixedReturnStatement Due to recursive dependencies, we can not have Memory installed as
+             *                                        during development. Will be installed during CI via
+             *                                        `.laminas-ci.json`.
+             */
+            return new Memory();
+        }
+
+        throw new RuntimeException('Unable to detect storage adapter for integration tests.');
+    }
+}

--- a/test/integration/AdapterPluginManagerDelegatorFactoryTest.php
+++ b/test/integration/AdapterPluginManagerDelegatorFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTestTest\Cache\Storage\Adapter;
+
+use Laminas\Cache\Storage\AdapterPluginManager;
+use LaminasTest\Cache\Storage\Adapter\PluginManagerDelegatorFactoryTestTrait;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class AdapterPluginManagerDelegatorFactoryTest extends TestCase
+{
+    use PluginManagerDelegatorFactoryTestTrait;
+
+    public static function getCommonAdapterNamesProvider(): iterable
+    {
+        return [];
+    }
+
+    public function getDelegatorFactory(): callable
+    {
+        return fn (ContainerInterface $container) => new AdapterPluginManager($container);
+    }
+}

--- a/test/integration/CacheItemPoolIntegrationTestTest.php
+++ b/test/integration/CacheItemPoolIntegrationTestTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTestTest\Cache\Storage\Adapter;
 
-use Laminas\Cache\Storage\Adapter\Apcu;
 use Laminas\Cache\Storage\StorageInterface;
 use LaminasTest\Cache\Storage\Adapter\AbstractCacheItemPoolIntegrationTest;
 
@@ -19,19 +18,8 @@ final class CacheItemPoolIntegrationTestTest extends AbstractCacheItemPoolIntegr
         parent::setUp();
     }
 
-    /**
-     * @psalm-suppress InvalidReturnType Due to recursive dependencies, we can not have APCu installed as during
-     *                                   development. Will be installed during CI via `.laminas-ci.json`.
-     */
     protected function createStorage(): StorageInterface
     {
-        /**
-         * @psalm-suppress UndefinedClass Due to recursive dependencies, we can not have APCu installed as during
-         *                                development. Will be installed during CI via `.laminas-ci.json`.
-         * @psalm-suppress InvalidReturnStatement Due to recursive dependencies, we can not have APCu installed as
-         *                                        during development. Will be installed during CI via
-         *                                        `.laminas-ci.json`.
-         */
-        return new Apcu();
+        return AdapterForIntegrationTestDetector::detect();
     }
 }

--- a/test/integration/SimpleCacheIntegrationTestTest.php
+++ b/test/integration/SimpleCacheIntegrationTestTest.php
@@ -4,25 +4,13 @@ declare(strict_types=1);
 
 namespace LaminasTestTest\Cache\Storage\Adapter;
 
-use Laminas\Cache\Storage\Adapter\Apcu;
 use Laminas\Cache\Storage\StorageInterface;
 use LaminasTest\Cache\Storage\Adapter\AbstractSimpleCacheIntegrationTest;
 
 final class SimpleCacheIntegrationTestTest extends AbstractSimpleCacheIntegrationTest
 {
-    /**
-     * @psalm-suppress InvalidReturnType Due to recursive dependencies, we can not have APCu installed as during
-     *                                   development. Will be installed during CI via `.laminas-ci.json`.
-     */
     protected function createStorage(): StorageInterface
     {
-        /**
-         * @psalm-suppress UndefinedClass Due to recursive dependencies, we can not have APCu installed as during
-         *                                development. Will be installed during CI via `.laminas-ci.json`.
-         * @psalm-suppress InvalidReturnStatement Due to recursive dependencies, we can not have APCu installed as
-         *                                        during development. Will be installed during CI via
-         *                                        `.laminas-ci.json`.
-         */
-        return new Apcu();
+        return AdapterForIntegrationTestDetector::detect();
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | yes

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

With #51  we provided support for PHPUnit v10+ but forgot to adapt the trait to require adapters to provide a static data provider as required by PHPUnit v10 onwards.

This also fixes issues with integration tests as there are integration tests with `Memory` and `APCu` adapter but only those with APCu would have worked.