### PR TITLE
Remove invalid keys which are not allowed due to type-safety

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,6 +1,7 @@
 {
     "extensions": ["apcu"],
     "ini": ["apc.enabled=1", "apc.enable_cli=1"],
+    "backwardCompatibilityCheck": true,
     "additional_checks": [
         {
             "name": "Integration tests with memory adapter",

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "laminas/laminas-cache": "^4.0",
         "phpunit/phpunit": "^10.5",
-        "psr/cache": "^1.0 || ^2.0 || ^3.0",
+        "psr/cache": "^2.0 || ^3.0",
         "psr/container": "^2.0",
-        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+        "psr/simple-cache": "^2.0 || ^3.0"
     },
     "require-dev": {
         "composer-plugin-api": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a7348a5e3d2290b82f8403343a499a2",
+    "content-hash": "110ede17bced2330b3bf068bc403b546",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/src/AbstractCacheItemPoolIntegrationTest.php
+++ b/src/AbstractCacheItemPoolIntegrationTest.php
@@ -31,6 +31,10 @@ use function sleep;
 use function str_repeat;
 use function time;
 
+/**
+ * NOTE: Most tests in here are imported from https://github.com/php-cache/integration-tests
+ *       cache/integration-tests is licensed with the MIT License.
+ */
 abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
 {
     /** @var non-empty-string|null */
@@ -89,11 +93,6 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
     public static function invalidKeys(): array
     {
         return [
-            [true],
-            [false],
-            [null],
-            [2],
-            [2.5],
             ['{str'],
             ['rand{'],
             ['rand{str'],
@@ -104,8 +103,6 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
             ['rand\\str'],
             ['rand@str'],
             ['rand:str'],
-            [new stdClass()],
-            [['array']],
         ];
     }
 

--- a/src/AbstractSimpleCacheIntegrationTest.php
+++ b/src/AbstractSimpleCacheIntegrationTest.php
@@ -28,6 +28,10 @@ use function sleep;
 use function sort;
 use function str_repeat;
 
+/**
+ * NOTE: Most tests in here are imported from https://github.com/php-cache/integration-tests
+ *       cache/integration-tests is licensed with the MIT License.
+ */
 abstract class AbstractSimpleCacheIntegrationTest extends TestCase
 {
     /** @var non-empty-string|null */
@@ -98,9 +102,6 @@ abstract class AbstractSimpleCacheIntegrationTest extends TestCase
     {
         return array_merge(
             self::invalidArrayKeys(),
-            [
-                [2],
-            ]
         );
     }
 
@@ -113,10 +114,6 @@ abstract class AbstractSimpleCacheIntegrationTest extends TestCase
     {
         return [
             [''],
-            [true],
-            [false],
-            [null],
-            [2.5],
             ['{str'],
             ['rand{'],
             ['rand{str'],
@@ -127,27 +124,6 @@ abstract class AbstractSimpleCacheIntegrationTest extends TestCase
             ['rand\\str'],
             ['rand@str'],
             ['rand:str'],
-            [new stdClass()],
-            [['array']],
-        ];
-    }
-
-    /**
-     * @return list<array{0:mixed}>
-     */
-    public static function invalidTtl(): array
-    {
-        return [
-            [''],
-            [true],
-            [false],
-            ['abc'],
-            [2.5],
-            [' 1'], // can be casted to a int
-            ['12foo'], // can be casted to a int
-            ['025'], // can be interpreted as hex
-            [new stdClass()],
-            [['array']],
         ];
     }
 
@@ -494,16 +470,6 @@ abstract class AbstractSimpleCacheIntegrationTest extends TestCase
         $this->cache->getMultiple(['key1', $key, 'key2']);
     }
 
-    public function testGetMultipleNoIterable(): void
-    {
-        if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-        }
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->cache->getMultiple('key');
-    }
-
     /**
      * @param mixed $key
      * @dataProvider invalidKeys
@@ -535,16 +501,6 @@ abstract class AbstractSimpleCacheIntegrationTest extends TestCase
         };
         $this->expectException(InvalidArgumentException::class);
         $this->cache->setMultiple($values());
-    }
-
-    public function testSetMultipleNoIterable(): void
-    {
-        if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-        }
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->cache->setMultiple('key');
     }
 
     /**
@@ -587,44 +543,6 @@ abstract class AbstractSimpleCacheIntegrationTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->cache->deleteMultiple(['key1', $key, 'key2']);
-    }
-
-    public function testDeleteMultipleNoIterable(): void
-    {
-        if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-        }
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->cache->deleteMultiple('key');
-    }
-
-    /**
-     * @param mixed $ttl
-     * @dataProvider invalidTtl
-     */
-    public function testSetInvalidTtl($ttl): void
-    {
-        if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-        }
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->cache->set('key', 'value', $ttl);
-    }
-
-    /**
-     * @param mixed $ttl
-     * @dataProvider invalidTtl
-     */
-    public function testSetMultipleInvalidTtl($ttl): void
-    {
-        if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-        }
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->cache->setMultiple(['key' => 'value'], $ttl);
     }
 
     public function testNullOverwrite(): void


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

In newer versions of `psr/cache` and `psr/simple-cache`, non-string cache keys are not possible anymore. Since `laminas/laminas-cache` v4 does not support those versions without type-safety, we can safely drop these.

