### PR TITLE
Ensure that when creating cache pools we do not receive reference of existing one

### DIFF
--- a/src/AbstractCacheItemPoolIntegrationTest.php
+++ b/src/AbstractCacheItemPoolIntegrationTest.php
@@ -412,6 +412,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
 
         // Use a new pool instance to ensure that we don't hit any caches
         $pool = $this->createCachePool();
+        self::assertNotEquals($pool, $this->cache, 'New cache pools must not reference existing one.');
         $item = $pool->getItem('test_ttl_null');
 
         self::assertTrue($item->isHit(), 'Cache should have retrieved the items');
@@ -513,6 +514,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
         gc_collect_cycles();
 
         $cache = $this->createCachePool();
+        self::assertNotEquals($cache, $this->cache, 'New cache pools must not reference existing one.');
         self::assertTrue(
             $cache->getItem('key')->isHit(),
             'A deferred item should automatically be committed on CachePool::__destruct().'


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
 QA            | yes

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

When testing with difference cache instances, we should verify that these are not referencing the existing storage.