### PR TITLE
Introduce sleep timer to speed up tests where expiry time is persisted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "laminas/laminas-cache": "^4.0.3",
         "phpunit/phpunit": "^10.5",
         "psr/cache": "^2.0 || ^3.0",
+        "psr/clock": "^1.0",
         "psr/container": "^2.0",
         "psr/simple-cache": "^2.0 || ^3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77d34df81c79493cb11d962b479139c5",
+    "content-hash": "8bda0b25111f2983cb1260bca5c05cca",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/src/AbstractCacheItemPoolIntegrationTest.php
+++ b/src/AbstractCacheItemPoolIntegrationTest.php
@@ -28,7 +28,6 @@ use function is_int;
 use function is_object;
 use function is_string;
 use function iterator_to_array;
-use function sleep;
 use function str_repeat;
 use function time;
 
@@ -40,6 +39,8 @@ use function time;
  */
 abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
 {
+    use ClockTrait;
+
     /** @var non-empty-string|null */
     private ?string $tz = null;
 
@@ -89,7 +90,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
     public function createCachePool(): CacheItemPoolInterface
     {
         $this->storage = $this->createStorage();
-        return new CacheItemPoolDecorator($this->storage);
+        return new CacheItemPoolDecorator($this->storage, $this->getClock());
     }
 
     /**
@@ -572,7 +573,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
         $item->expiresAfter(2);
         $this->cache->save($item);
 
-        sleep(3);
+        $this->advanceTime(3);
         $item = $this->cache->getItem('key');
         self::assertFalse($item->isHit());
         self::assertNull($item->get(), "Item's value must be null when isHit() is false.");
@@ -1001,7 +1002,7 @@ abstract class AbstractCacheItemPoolIntegrationTest extends TestCase
         $item->expiresAfter(2);
         $this->cache->saveDeferred($item);
 
-        sleep(3);
+        $this->advanceTime(3);
         self::assertFalse($this->cache->hasItem('key'));
     }
 }

--- a/src/AbstractCommonAdapterTest.php
+++ b/src/AbstractCommonAdapterTest.php
@@ -48,6 +48,8 @@ use function usleep;
  */
 abstract class AbstractCommonAdapterTest extends TestCase
 {
+    use ClockTrait;
+
     /** @var TStorage */
     protected StorageInterface $storage;
 
@@ -196,10 +198,10 @@ abstract class AbstractCommonAdapterTest extends TestCase
         self::assertTrue($this->storage->setItem('key', 'value'));
 
         // wait until the item expired
-        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2000000);
+        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
-        usleep($wait);
+        $this->advanceTime($wait);
 
         if (! $capabilities->usesRequestTime) {
             self::assertFalse($this->storage->hasItem('key'));
@@ -275,10 +277,10 @@ abstract class AbstractCommonAdapterTest extends TestCase
         $this->storage->setItem('key', 'value');
 
         // wait until expired
-        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2000000);
+        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
-        usleep($wait);
+        $this->advanceTime($wait);
 
         self::assertNull($this->storage->getItem('key'));
     }
@@ -525,10 +527,10 @@ abstract class AbstractCommonAdapterTest extends TestCase
         $this->storage->setItem('key', 'value');
 
         // wait until expired
-        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2000000);
+        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
-        usleep($wait);
+        $this->advanceTime($wait);
 
         if ($capabilities->usesRequestTime) {
             // Can't test much more if the request time will be used
@@ -571,10 +573,10 @@ abstract class AbstractCommonAdapterTest extends TestCase
         self::assertSame([], $this->storage->setItems($itemsLow));
 
         // wait until expired
-        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2000000);
+        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
-        usleep($wait);
+        $this->advanceTime($wait);
 
         $rs = $this->storage->getItems(array_keys($items));
         ksort($rs); // make comparable
@@ -692,10 +694,10 @@ abstract class AbstractCommonAdapterTest extends TestCase
         self::assertTrue($this->storage->addItem('key', 'value'));
 
         // wait until the item expired
-        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2000000);
+        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
-        usleep($wait);
+        $this->advanceTime($wait);
 
         if (! $capabilities->usesRequestTime) {
             self::assertFalse($this->storage->hasItem('key'));
@@ -775,24 +777,24 @@ abstract class AbstractCommonAdapterTest extends TestCase
         $this->options->setTtl(2 * $capabilities->ttlPrecision);
 
         $this->waitForFullSecond();
-        $waitInitial = (int) ($capabilities->ttlPrecision * 1000000);
+        $waitInitial = (int) $capabilities->ttlPrecision;
         self::assertGreaterThanOrEqual(0, $waitInitial);
         assert($waitInitial >= 0);
 
         self::assertTrue($this->storage->setItem('key', 'value'));
 
         // sleep 1 times before expire to touch the item
-        usleep($waitInitial);
+        $this->advanceTime($waitInitial);
         self::assertTrue($this->storage->touchItem('key'));
 
-        usleep($waitInitial);
+        $this->advanceTime($waitInitial);
         self::assertTrue($this->storage->hasItem('key'));
 
         if (! $capabilities->usesRequestTime) {
-            $waitExtended = (int) ($capabilities->ttlPrecision * 2000000);
+            $waitExtended = (int) ($capabilities->ttlPrecision * 2);
             self::assertGreaterThanOrEqual(0, $waitExtended);
             assert($waitExtended >= 0);
-            usleep($waitExtended);
+            $this->advanceTime($waitExtended);
             self::assertFalse($this->storage->hasItem('key'));
         }
     }
@@ -965,10 +967,10 @@ abstract class AbstractCommonAdapterTest extends TestCase
         self::assertTrue($this->storage->setItem('key1', 'value1'));
 
         // wait until the first item expired
-        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2000000);
+        $wait = (int) ($ttl + $capabilities->ttlPrecision * 2);
         self::assertGreaterThanOrEqual(0, $wait);
         assert($wait >= 0);
-        usleep($wait);
+        $this->advanceTime($wait);
 
         self::assertTrue($this->storage->setItem('key2', 'value2'));
 

--- a/src/AbstractSimpleCacheIntegrationTest.php
+++ b/src/AbstractSimpleCacheIntegrationTest.php
@@ -24,7 +24,6 @@ use function is_float;
 use function is_int;
 use function is_object;
 use function is_string;
-use function sleep;
 use function sort;
 use function str_repeat;
 
@@ -34,6 +33,8 @@ use function str_repeat;
  */
 abstract class AbstractSimpleCacheIntegrationTest extends TestCase
 {
+    use ClockTrait;
+
     /** @var non-empty-string|null */
     private ?string $tz = null;
 
@@ -75,22 +76,7 @@ abstract class AbstractSimpleCacheIntegrationTest extends TestCase
     public function createSimpleCache(): CacheInterface
     {
         $this->storage = $this->createStorage();
-        return new SimpleCacheDecorator($this->storage);
-    }
-
-    /**
-     * Advance time perceived by the cache for the purposes of testing TTL.
-     *
-     * The default implementation sleeps for the specified duration,
-     * but subclasses are encouraged to override this,
-     * adjusting a mocked time possibly set up in {@link createSimpleCache()},
-     * to speed up the tests.
-     *
-     * @param 0|positive-int $seconds
-     */
-    protected function advanceTime(int $seconds): void
-    {
-        sleep($seconds);
+        return new SimpleCacheDecorator($this->storage, $this->getClock());
     }
 
     /**

--- a/src/ClockTrait.php
+++ b/src/ClockTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Storage\Adapter;
+
+use Psr\Clock\ClockInterface;
+
+use function sleep;
+
+trait ClockTrait
+{
+    /**
+     * Advance time perceived by the cache for the purposes of testing TTL.
+     *
+     * The default implementation sleeps for the specified duration,
+     * but subclasses are encouraged to override this,
+     * adjusting a mocked time possibly speed up the tests.
+     *
+     * One could use {@see ModifiableClockTrait} for example, but this won't work for all adapters.
+     *
+     * @param non-negative-int $seconds
+     */
+    protected function advanceTime(int $seconds): void
+    {
+        sleep($seconds);
+    }
+
+    protected function getClock(): ClockInterface|null
+    {
+        return null;
+    }
+}

--- a/src/ModifiableClock.php
+++ b/src/ModifiableClock.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Storage\Adapter;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use Psr\Clock\ClockInterface;
+
+use function assert;
+use function sprintf;
+
+/**
+ * @psalm-api
+ */
+final class ModifiableClock implements ClockInterface
+{
+    private DateTimeImmutable $frozenTime;
+
+    /** @var non-negative-int */
+    private int $secondsToAdd = 0;
+
+    public function __construct(DateTimeZone $timeZone)
+    {
+        $this->frozenTime = new DateTimeImmutable(timezone: $timeZone);
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        $interval = DateInterval::createFromDateString(sprintf('%d seconds', $this->secondsToAdd));
+        assert($interval !== false);
+        return $this->frozenTime->add($interval);
+    }
+
+    /**
+     * @param non-negative-int $seconds
+     */
+    public function addSeconds(int $seconds): void
+    {
+        $this->secondsToAdd += $seconds;
+    }
+}

--- a/src/ModifiableClockTrait.php
+++ b/src/ModifiableClockTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Storage\Adapter;
+
+use DateTimeZone;
+
+use function date_default_timezone_get;
+
+trait ModifiableClockTrait
+{
+    private ?ModifiableClock $modifiableClock = null;
+
+    /**
+     * Advance time perceived by the cache for the purposes of testing TTL.
+     * This method uses the modifiable clock to internally add seconds to a frozen timestamp.
+     *
+     * @param non-negative-int $seconds
+     */
+    protected function advanceTime(int $seconds): void
+    {
+        $this->modifiableClock?->addSeconds($seconds);
+    }
+
+    protected function getClock(): ModifiableClock
+    {
+        if ($this->modifiableClock !== null) {
+            return $this->modifiableClock;
+        }
+        return $this->modifiableClock = new ModifiableClock(new DateTimeZone(date_default_timezone_get()));
+    }
+}

--- a/test/unit/ModifiableClockTest.php
+++ b/test/unit/ModifiableClockTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTestTest\Cache\Storage\Adapter;
+
+use DateTimeInterface;
+use DateTimeZone;
+use LaminasTest\Cache\Storage\Adapter\ModifiableClock;
+use PHPUnit\Framework\TestCase;
+
+use function date_default_timezone_get;
+
+final class ModifiableClockTest extends TestCase
+{
+    public function testAddSecondsAddsUpSeconds(): void
+    {
+        $clock = new ModifiableClock(new DateTimeZone(date_default_timezone_get()));
+        $time  = $clock->now();
+
+        $clock->addSeconds(2);
+        $timeWithAddedSeconds = $clock->now();
+
+        self::assertSame(
+            $time->modify('2 seconds')->format(DateTimeInterface::ATOM),
+            $timeWithAddedSeconds->format(DateTimeInterface::ATOM),
+        );
+
+        $clock->addSeconds(2);
+        $timeWithAddedSeconds = $clock->now();
+
+        self::assertSame(
+            $time->modify('4 seconds')->format(DateTimeInterface::ATOM),
+            $timeWithAddedSeconds->format(DateTimeInterface::ATOM),
+        );
+    }
+}

--- a/test/unit/ModifiableClockTraitTest.php
+++ b/test/unit/ModifiableClockTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTestTest\Cache\Storage\Adapter;
 
+use DateTimeInterface;
 use LaminasTest\Cache\Storage\Adapter\ModifiableClockTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -15,5 +16,23 @@ final class ModifiableClockTraitTest extends TestCase
     {
         $clock = $this->getClock();
         self::assertSame($clock, $this->getClock());
+    }
+
+    public function testAdvanceTimeCanBeCalledWithoutInitializingClock(): void
+    {
+        self::assertNull($this->modifiableClock);
+        $this->advanceTime(10);
+    }
+
+    public function testAdvanceTimePassesSecondsToModifiableClock(): void
+    {
+        $clock = $this->getClock();
+        $time  = $clock->now();
+
+        $this->advanceTime(10);
+        self::assertSame(
+            $time->modify('10 seconds')->format(DateTimeInterface::ATOM),
+            $clock->now()->format(DateTimeInterface::ATOM),
+        );
     }
 }

--- a/test/unit/ModifiableClockTraitTest.php
+++ b/test/unit/ModifiableClockTraitTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTestTest\Cache\Storage\Adapter;
+
+use LaminasTest\Cache\Storage\Adapter\ModifiableClockTrait;
+use PHPUnit\Framework\TestCase;
+
+final class ModifiableClockTraitTest extends TestCase
+{
+    use ModifiableClockTrait;
+
+    public function testGetClockReturnsSameClockWhenCallingMultipleTimes(): void
+    {
+        $clock = $this->getClock();
+        self::assertSame($clock, $this->getClock());
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

By default, the abstract adapter tests do use the `ClockTrait` which uses `sleep` as before. This is necessary due to the fact that some adapters use dedicated services to persist cache values where we can't modify the time. Some cache adapters, such as `Memory` and `Filesystem`, persist the expiry timestamp and thus, the clock can be modified so that cache items are detected as expired.

With this patch, we introduce `ClockTrait` and `ModifiableClockTrait` where the latter can be used in adapters which persist the expiry timestamp.